### PR TITLE
Updates for non-ephemeral migration instance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 =================
 
 - Fixed issue with wrong path to QA id catalog input path.
+- Fixed bucket S3 path for Datomic db backup.
 
 
 0.17 (2016-06-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@
 - Fixed bucket S3 path for Datomic db backup.
 - datomic-free does not support direct `s3` upload -
   work around that with local back and upload via AWS APIs.
+- Updates to reflect switch to non-ephemeral instance.
 
 
 0.17 (2016-06-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Fixed issue with wrong path to QA id catalog input path.
 - Fixed bucket S3 path for Datomic db backup.
+- datomic-free does not support direct `s3` upload -
+  work around that with local back and upload via AWS APIs.
 
 
 0.17 (2016-06-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 0.18 (unreleased)
 =================
 
-- Nothing changed yet.
+- Fixed issue with wrong path to QA id catalog input path.
 
 
 0.17 (2016-06-27)

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 A Python (3) package providing a set of Command Line Interfaces (CLI)
 for performing tasks to realise the Datomic database migration from
-ACeDB to Datomic, on a dedicated ephemeral AWS instance.
+ACeDB to Datomic, on an AWS instance.
 
 Documentation_.
 

--- a/docs/source/admin/ec2-instance-creation.rst
+++ b/docs/source/admin/ec2-instance-creation.rst
@@ -1,0 +1,20 @@
+=========================
+AWS EC2 Instance Creation
+=========================
+The instance to be used for the db migration should be created with
+the following command:
+
+.. code-block:: bash
+
+   RELEASE="WS...."
+   SUBNET_ID="subnet-xxxxx"
+   azanium --profile="${AWS_CLI_ADMIN_ACCOUNT}" \
+	 cloud init "${RELEASE}" "${subnet_id}"
+
+In the above, `SUBNET_ID` should be the id of the subnet in the new
+EC2-VPC named "wormbase".
+
+The command above in effect,  wraps the typical `aws ec2 run-instances` command to install the `azanium` software on the instance, and pre-configure the instance with
+`UserData`, as follows:
+
+.. literalinclude:: ../../../src/azanium/cloud-config/AWS-cloud-config-UserData.template

--- a/docs/source/admin/ec2-instance.rst
+++ b/docs/source/admin/ec2-instance.rst
@@ -30,7 +30,7 @@ performing a database migration.
 +----------+------------------+--------------------+----------+
 |/dev/xvda1|/                 |EBS, SSD            |60Gb      |
 +----------+------------------+--------------------+----------+
-|/dev/xvdb |/media/ephemeral0 |Instance Store, SSD |320Gb     |
+|/dev/xvdb |/wormbase         |Instance Store, SSD |320Gb     |
 +----------+------------------+--------------------+----------+
 
 Security properties

--- a/docs/source/admin/index.rst
+++ b/docs/source/admin/index.rst
@@ -4,8 +4,8 @@ Administration
 This documentation is intended for those managing the WormBase
 :term:`AWS` accounts; detailed here:
 
-   * Steps required to configure the AWS :term:`IAM` service
-     in order for users who are to perform the database migration.
+   * Steps required to configure the AWS :term:`IAM` users
+     in order to perform the database migration.
 
    * Details of the  :term:`EC2` instance required to perform the database migration
 
@@ -15,4 +15,5 @@ This documentation is intended for those managing the WormBase
    :hidden:
 
    iam-setup
+   ec2-instance-creation
    ec2-instance

--- a/docs/source/dev/testing.rst
+++ b/docs/source/dev/testing.rst
@@ -11,11 +11,11 @@ The installation procedure "bootstraps" the instance with a distribution
 of this package.
 
 When manually testing, please pass the ``--dev-mode`` flag to
-``azanium cloud`` command, e.g:
+``azanium admin`` command, e.g:
 
 .. code-block:: bash
 
-   azanium cloud init --dev-mode WS254
+   azanium admin create-instance --dev-mode WS254 "${SUBNET_ID}"
 
 This will bootstrap the instance with the code from your local working
 directory.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -13,13 +13,12 @@ Glossary
       The :term:`azanium` sub-command used to administer WormBase AWS
       accounts for the database migration.
 
-   `azanium cloud`
-      The :term:`azanium` sub-command used from a client machine to
-      interact with :term:`AWS`.
-
    `azanium run`
       The :term:`azanium` sub-command used on an :term:`AWS`
       :term:`EC2` instance in order to perform the database migration.
+
+   `aws cli`
+      The `Amazon Command Line Interface`_
 
    AWS
       Amazon Web Services - the umbrella term for all of the Amazon
@@ -76,3 +75,4 @@ Glossary
 .. _`Amazon Resource Name`: http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
 .. _`Amazon Identity and Access Management`: http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html
 .. _circus: https://circus.readthedocs.io/en/latest/
+.. _`Amazon Command Line Interface`: https://aws.amazon.com/cli/

--- a/docs/source/user/commands.rst
+++ b/docs/source/user/commands.rst
@@ -40,7 +40,7 @@ which can be restored using any recent version of :term:`Datomic`.
    The output in JSON format, and should contain the following when the
    instance is ready:
 
-   .. code-block:: json
+   .. code-block:: text
 
       "State": {
         "Code": 16,

--- a/docs/source/user/commands.rst
+++ b/docs/source/user/commands.rst
@@ -41,6 +41,7 @@ which can be restored using any recent version of :term:`Datomic`.
    instance is ready:
 
    .. code-block:: json
+
       "State": {
         "Code": 16,
         "Name": "running"

--- a/docs/source/user/commands.rst
+++ b/docs/source/user/commands.rst
@@ -12,25 +12,47 @@ which can be restored using any recent version of :term:`Datomic`.
 
 .. _db-migration-step-1:
 
-1. **Provision and bootstrap an EC2 instance**
+1. **Start the DB Migration EC2 instance**
 
-   The following :term:`azanium` sub-command below will
-   print out the ssh commands needed for the next step.
+   Assuming you have correctly setup AWS Command Line Interface, using
+   the `db migration ec2 instance id` provided by a WormBase AWS
+   Administrator, enter the following :term:`aws cli` command to start
+   the migration instance:
 
    .. code-block:: bash
 
       AWS_PROFILE="${USER}"
-      WB_DATA_RELEASE="WS254"
-      azanium cloud --profile "${USER}" init "${WB_DATA_RELEASE}"
+      INSTANCE_ID="${INSTANCE_ID_PROVIDED_BY_WORMBASE_AWS_ADMIN}"
+      aws --profile "${AWS_PROFILE}" \
+		   ec2 start-instances --instance-ids "${INSTANCE_ID}"
 
 .. _db-migration-step-2:
 
 2. **Connect to the EC2 instance using ssh - run the migrate command**
 
+   Use the following command check the status of the instance:
+
+   .. code-block:: bash
+
+      aws --profile="${AWS_PROFILE}" \
+		   ec2 describe-instances --instance-ids "${INSTANCE_ID}"
+
+   The output in JSON format, and should contain the following when the
+   instance is ready:
+
+   .. code-block:: json
+      "State": {
+        "Code": 16,
+        "Name": "running"
+      }
+
+   Once runnuing, either the `PublicDnsName` or `PublicIPAddress` mentioned in
+   same output can be used to connect to the instance via `ssh` using an
+   ssh provided by a WormBase :term:`AWS` administrator.
+
    The commands below will emit their current progress to the console,
    and will also print out the location of a log file for more detailed
    output.
-
 
    Use the `ssh` command printed from step 1 to connect to the EC2 instance.
 
@@ -74,7 +96,7 @@ which can be restored using any recent version of :term:`Datomic`.
 
    .. code-block:: bash
 
-      azanium cloud --profile $USER terminate
+      azanium --profile $USER admin stop-instance
 
 
 Should all steps complete successfully, the migration process is now

--- a/docs/source/user/index.rst
+++ b/docs/source/user/index.rst
@@ -1,9 +1,9 @@
 ============================
 Database Migration Procedure
 ============================
-The database migration will be performed on an ephemeral :term:`EC2`
-instance.  Upon successful completion, the migrated Datomic database
-will be stored in :term:`S3` storage.
+The database migration will be performed on an :term:`EC2` instance.
+Upon successful completion, the migrated Datomic database will be
+stored in :term:`S3` storage.
 
 The migration process will take approximately 3½ days to complete.
 
@@ -19,6 +19,5 @@ the migration process.
    :maxdepth: 1
 
    prerequisites
-   setup
    notifications
    commands

--- a/docs/source/user/index.rst
+++ b/docs/source/user/index.rst
@@ -20,4 +20,5 @@ the migration process.
 
    prerequisites
    notifications
+   setup
    commands

--- a/docs/source/user/notifications.rst
+++ b/docs/source/user/notifications.rst
@@ -11,19 +11,25 @@ dedicated :term:`Slack` channel:
 .. note:: Notification support requires access to the WormBase DB
           Development slack group
 
-As a user performing database migration, you should have received an invite,
-or otherwise subscribed to this channel.
+As a user performing database migration, you should have received an
+invitation, or otherwise subscribed to this channel.
 
 Notifications are sent before and after each build step; at the end of
 the process a notification will sent to confirm the migrated Datomic
 databases’ location on Amazon :term:`S3` storage To configure
 notifications for you and the WormBase team:
 
-Enter the `slack webhook url`_ to the following command:
+Enter the `slack webhook url`_ into a file in your home directory,
+named as follows:
 
-.. code-block:: bash
+ `~/.azanium.conf`
 
-  azanium configure <SLACK_WEBHOOK_URL>
+The format of the file should match the following:
+
+.. code-block:: ini
+
+   [azanium.notifications]
+   url = https://hooks.slack.com/services/<UNIQUE_TOKEN_1>/<UNIQUE_TOKEN_2>
 
 
 .. _`slack webhook url`: https://wormbase-db-dev.slack.com/services/B1HNK2JEM#service_setup

--- a/docs/source/user/prerequisites.rst
+++ b/docs/source/user/prerequisites.rst
@@ -13,10 +13,15 @@ Prerequisites
 
   	*AWS_SECRET_ACCESS_KEY*
 
-  * Python 3.4+
+  * :term:`AWS` Command Line Interface (`aws cli`)
 
-    On a unix-like machine, check the version with:
+   `Install the aws cli`_.
 
-    .. code-block:: bash
+   As a user who will perform the database migration, a WormBase AWS
+   administrator should provide you with the `Access Key ID` and
+   `Secret Access Key` credentials mentioned in the `Getting Started`_
+   section of the AWS Command Line Interface documentation.
 
-       $ which python3 && python3 -V
+
+.. _`Install the aws cli`: https://aws.amazon.com/cli/
+.. _`Getting Started`: http://docs.aws.amazon.com/cli/latest/userguide/

--- a/docs/source/user/setup.rst
+++ b/docs/source/user/setup.rst
@@ -5,17 +5,7 @@ Setup
 Installation requirements
 =========================
 
-Python 3.4+ is the only requirement.
-To test if your system has this version or higher:
-
-.. code-block:: bash
-
-   python -V
-
-If your system does not already contain Python >= 3.4, then please use
-your operating system's package manager (e.g apt, yum, brew) to obtain
-a suitable version, or download and install throm e latest version of
-`Python 3`_ from the Python website.
+Python_ is the only requirement.
 
 
 Python package management
@@ -34,19 +24,6 @@ Linux
 Mac OSX
   ``${HOME}/Library``
 
-Check to make sure you have ``pip3`` available:
-
-.. code-block:: bash
-
-   $ which pip3
-
-Otherwise, for the purpose of following along with this documentation;
-set a shell alias:
-
-.. code-block:: bash
-
-   alias pip3="python3 -m pip"
-
 
 :term:`AWS` :term:`CLI` and :term:`azanium` Installation
 ========================================================
@@ -56,8 +33,7 @@ repository's `latest release page`_.
 
 .. code-block:: bash
 
-   pip3 install --user awscli
-   pip3 install --user <AZANIUM-WHEEL-URL>
+   pip install --user awscli
 
 
 :term:`AWS` Configuration
@@ -83,6 +59,22 @@ These credentials should be given as input to the following command:
    aws configure --profile $USER
 
 
+Next, you should modify the file:
+
+  `~/.aws/config`
+
+and add the following profile as shown below, substituting `$USER` for
+the actual profile name used in the `aws configure` command above:
+
+.. code-block:: ini
+
+   [profile wb-db-migrator]
+   region = us-east-1
+   role_session_name = wb-db-migrator
+   role_arn = arn:aws:iam::357210185381:role/wb-db-migrator
+   source_profile = $USER
+
+
 Environment limitations
 =======================
 The :term:`client commands` used to interact with :term:`AWS` expects
@@ -102,7 +94,7 @@ the following files must be copied (in addition to installing the software):
 
 .. note:: The above assumes you've run all commands from your `$HOME` directory.
 
-.. _`Python 3`: https://www.python.org/downloads/
+.. _Python: https://www.python.org/downloads/
 .. _pip: https://en.wikipedia.org/wiki/Pip_(package_manager)
 .. _`AWS region`: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
 .. _`latest release page`: https://github.com/Wormbase/db-migration/releases/latest

--- a/docs/source/user/setup.rst
+++ b/docs/source/user/setup.rst
@@ -86,7 +86,7 @@ These credentials should be given as input to the following command:
 Environment limitations
 =======================
 The :term:`client commands` used to interact with :term:`AWS` expects
-that all `azanium cloud` commands to be invoked from the same working
+that all `azanium admin` commands to be invoked from the same working
 directory, from the same computer the initial commands are run from.
 
 If for some reason, its desired to run this command from a different machine,

--- a/src/azanium/__init__.py
+++ b/src/azanium/__init__.py
@@ -56,7 +56,9 @@ def root_command(ctx, log_level, base_path, profile, assume_role):
     command_context.user_profile = profile
     command_context.db_mig_state = util.aws_state()
     ctx.obj = command_context
-    logfile_path = os.path.join(base_path, 'logs')
+    logfile_path = os.path.join(base_path,
+                                'logs',
+                                '{}.log'.format(__package__))
     command_context.logfile_path = logfile_path
     log.setup_logging(logfile_path, log_level=log_level)
 

--- a/src/azanium/__init__.py
+++ b/src/azanium/__init__.py
@@ -11,7 +11,7 @@ from . import notifications
 from . import params
 from . import util
 
-INSTANCE_BASE_PATH = '/media/ephemeral0/wormbase'
+INSTANCE_BASE_PATH = '/wormbase'
 
 @util.command_group()
 @util.log_level_option()

--- a/src/azanium/admin.py
+++ b/src/azanium/admin.py
@@ -88,7 +88,7 @@ def setup(session):
         awsiam.ensure_assume_role_policy(iam,
                                          role,
                                          aws_meta.assume_role_policy_name)
-        ctx.invoke(sync, session)
+        ctx.invoke(sync_users, session)
     except Exception as e:
         util.echo_error(e)
         ctx.abort()
@@ -127,13 +127,13 @@ def add_user(session, username):
                     user.arn)
 
 
-@admin.command('users',
+@admin.command('list-users',
                short_help='Lists users of the db migration group')
 @util.option('--verify/--no-verify',
              default=True,
              help='Switch to check if users are correctly configured.')
 @pass_admin_session
-def users(session, verify):
+def list_users(session, verify):
     """List and verify IAM accounts allowed to perform db migration commands.
     """
     iam = session.resource('iam')
@@ -150,9 +150,10 @@ def users(session, verify):
     click.secho(json.dumps(users, indent=True, sort_keys=True), fg='cyan')
 
 
-@admin.command(short_help='Synchronizes all database migration-users')
+@admin.command('sync-users',
+               short_help='Synchronizes all database migration-users')
 @pass_admin_session
-def sync(session):
+def sync_users(session):
     """Synchronize members of the database migration group.
 
     This command ensures that users belonging to the designated group

--- a/src/azanium/awscloudops.py
+++ b/src/azanium/awscloudops.py
@@ -376,8 +376,11 @@ def upload_file(ctx, path_to_upload, path_in_bucket, bucket_name):
         'ACL': 'public-read'
     }
     ct_match = mimetypes.guess_type(path_to_upload)
-    if ct_match:
-        extra_args['ContentType'] = ct_match[0]
+    if all(ct_match):
+        content_type = ct_match[0]
+    else:
+        content_type = 'text/plain'
+    extra_args['ContentType'] = content_type
     try:
         logger.debug('{} (assumed role:{}) '
                      'is attempting to upload {} to s3://{}/{}',

--- a/src/azanium/cloud-config/AWS-cloud-config-UserData.template
+++ b/src/azanium/cloud-config/AWS-cloud-config-UserData.template
@@ -17,7 +17,8 @@ packages:
 
 bootcmd:
 - mkfs.ext4 /dev/xvdb
-- mount /dev/xvdb
+- mkdir -p /wormbase
+- mount /dev/xvdb /wormbase
 
 runcmd:
 - yum groupinstall -y "Development Tools"
@@ -32,8 +33,8 @@ runcmd:
 - ln -s /lib64/libreadline.so.6 /lib64/libreadline.so.5
 - cat %(azanium_completion_script)s >> ~ec2-user/.bashrc
 - chown ec2-user ~ec2-user/.bashrc
-- mkdir /media/ephemeral0/wormbase
-- chown ec2-user:ec2-user /media/ephemeral0/wormbase
+- mkdir /wormbase
+- chown ec2-user:ec2-user /wormbase
 
 
 output : { all : '| tee -a /var/log/cloud-init-output.log' }

--- a/src/azanium/cloud-config/versions.ini
+++ b/src/azanium/cloud-config/versions.ini
@@ -2,6 +2,6 @@
 [default]
 acedb_database = WS254
 acedb_id_catalog = WS254
-datomic_free = 0.9.5359
-pseudoace = 0.4.8
+datomic_free = 0.9.5385
+pseudoace = 0.4.9
 tace = 64.4.9.60

--- a/src/azanium/datomic.py
+++ b/src/azanium/datomic.py
@@ -14,7 +14,11 @@ def backup_db(context, db):
     from_uri = context.datomic_url(db)
     date_stamp = datetime.date.today().isoformat()
     to_uri = 's3://wormbase/db-migration/{}/{}'.format(date_stamp, db)
-    cmd = ['bin/datomic', util.jvm_mem_opts(0.20), from_uri, to_uri]
+    cmd = ['bin/datomic',
+           util.jvm_mem_opts(0.20),
+           'backup-db',
+           from_uri,
+           to_uri]
     cwd = context.path('datomic_free')
     logger.info('Backing up database {} to {}', from_uri, to_uri)
     util.local(cmd, cwd=cwd)

--- a/src/azanium/datomic.py
+++ b/src/azanium/datomic.py
@@ -1,3 +1,4 @@
+import datetime
 import time
 
 from configobj import ConfigObj
@@ -11,7 +12,8 @@ logger = log.get_logger(namespace=__name__)
 
 def backup_db(context, db):
     from_uri = context.datomic_url(db)
-    to_uri = 's3://wb-datomic-backups/' + db
+    date_stamp = datetime.date.today().isoformat()
+    to_uri = 's3://wormbase/db-migration/{}/{}'.format(date_stamp, db)
     cmd = ['bin/datomic', util.jvm_mem_opts(0.20), from_uri, to_uri]
     cwd = context.path('datomic_free')
     logger.info('Backing up database {} to {}', from_uri, to_uri)

--- a/src/azanium/datomic.py
+++ b/src/azanium/datomic.py
@@ -1,4 +1,3 @@
-import datetime
 import time
 
 from configobj import ConfigObj
@@ -10,10 +9,9 @@ from . import util
 logger = log.get_logger(namespace=__name__)
 
 
-def backup_db(context, db):
-    from_uri = context.datomic_url(db)
-    date_stamp = datetime.date.today().isoformat()
-    to_uri = 's3://wormbase/db-migration/{}/{}'.format(date_stamp, db)
+def backup_db(context, local_backup_path):
+    from_uri = context.datomic_url(context.db_name)
+    to_uri = 'file://' + local_backup_path
     cmd = ['bin/datomic',
            util.jvm_mem_opts(0.20),
            'backup-db',
@@ -23,7 +21,6 @@ def backup_db(context, db):
     logger.info('Backing up database {} to {}', from_uri, to_uri)
     util.local(cmd, cwd=cwd)
     logger.info('Database backup complete')
-    return to_uri
 
 
 def configure_transactor(context, datomic_path):

--- a/src/azanium/log.py
+++ b/src/azanium/log.py
@@ -84,8 +84,9 @@ class VerbosePrettyLogger(Logger):
         return super(VerbosePrettyLogger, self).exception(msg, *args, **kw)
 
 
-def setup_logging(log_dir, log_level=logging.INFO):
-    log_filename = __package__ + '.log'
+def setup_logging(logfile_path, log_level=logging.INFO):
+    log_dir = os.path.dirname(logfile_path)
+    log_filename = os.path.basename(logfile_path)
     os.makedirs(log_dir, exist_ok=True)
     log_path = os.path.join(log_dir, log_filename)
     logging.basicConfig(filename=log_path,

--- a/src/azanium/pseudoace.py
+++ b/src/azanium/pseudoace.py
@@ -63,10 +63,12 @@ def import_logs(context, edn_logs_dir):
 
 def qa_report(context, acedb_id_catalog_path):
     data_release = context.data_release_version
+    build_data_filename = 'all_classes_report.{}.txt'.format(data_release)
+    build_data_path = os.path.join(acedb_id_catalog_path, build_data_filename)
     out_path = os.path.expanduser(
         '~/{release}-report.txt'.format(release=data_release))
     run_pseudoace(context,
-                  '--build-data=' + acedb_id_catalog_path,
+                  '--build-data=' + build_data_path,
                   '--report-filename=' + out_path,
                   'generate-report')
     return out_path

--- a/src/azanium/runcommand.py
+++ b/src/azanium/runcommand.py
@@ -178,11 +178,12 @@ def migrate(context):
     step_idx = int(context.db_mig_state.get(LAST_STEP_OK_STATE_KEY, '0'))
     steps = [('Installing all software and ACeDB',
               partial(install.all.invoke, ctx))]
-    logfile_name = os.path.basename(context.logfile_path)
+    path_in_bucket = '/'.join(['db-migration',
+                               os.path.basename(context.logfile_path)])
     upload_log_file = partial(ctx.invoke,
                               awscloudops.upload_file,
                               path_to_upload=context.logfile_path,
-                              path_in_bucket=logfile_name)
+                              path_in_bucket=path_in_bucket)
     meta_steps = [
         ('Dumping all ACeDB files',
          acedb_dump,

--- a/src/azanium/runcommand.py
+++ b/src/azanium/runcommand.py
@@ -1,9 +1,13 @@
+import datetime
 import os
 import psutil
+import shutil
+import tarfile
 import tempfile
 import time
 from functools import partial
 
+from botocore.exceptions import ClientError
 import click
 
 from . import awscloudops
@@ -137,7 +141,32 @@ def backup_db_to_s3(context):
     prompt = 'Backup Datomic Database to S3? [y/N]:'
     if not input(prompt).lower().startswith('y'):
         click.get_current_context().abort()
-    s3_uri = datomic.backup_db(context, context.data_release_version)
+    data_release_version = context.data_release_version
+    date_stamp = datetime.date.today().isoformat()
+    local_backup_path = '/tmp/' + os.path.join('db-migration',
+                                               date_stamp,
+                                               context.db_name)
+    archive_path = os.path.join(os.path.dirname(local_backup_path),
+                                '{}.tar.xz'.format(data_release_version))
+    arcname = os.path.basename(local_backup_path)
+    if not os.path.isdir(local_backup_path):
+        datomic.backup_db(context, local_backup_path)
+    if not os.path.isfile(archive_path):
+        with tarfile.open(archive_path, mode='w:xz') as tf:
+            tf.add(local_backup_path, arcname=arcname)
+    ctx = click.get_current_context()
+    try:
+        s3_uri = ctx.invoke(awscloudops.upload_file,
+                            path_to_upload=archive_path,
+                            path_in_bucket='db-migration/' + arcname)
+    except ClientError:
+        logger.error('Failed to upload file to S3')
+        logger.exception()
+        raise
+    else:
+        logger.info('Removing local datomic db backup {}', local_backup_path)
+        os.remove(archive_path)
+        shutil.rmtree(local_backup_path)
     return 'Datomic database transferred to {uri}.'.format(uri=s3_uri)
 
 

--- a/src/azanium/runcommand.py
+++ b/src/azanium/runcommand.py
@@ -29,8 +29,7 @@ LAST_STEP_OK_STATE_KEY = 'last-step-ok-idx'
 @root_command.group()
 @util.pass_command_context
 def run(context):
-    """Commands for executing db migration on an ephemeral AWS EC2 instance.
-    """
+    """Commands for executing db migration on an AWS EC2 instance."""
 
 
 @run.command('acedb-compress-dump',
@@ -143,9 +142,10 @@ def backup_db_to_s3(context):
         click.get_current_context().abort()
     data_release_version = context.data_release_version
     date_stamp = datetime.date.today().isoformat()
-    local_backup_path = '/tmp/' + os.path.join('db-migration',
-                                               date_stamp,
-                                               context.db_name)
+    local_backup_path = context.path('datomic-db-backup')
+    local_backup_path = os.path.join(local_backup_path,
+                                     date_stamp,
+                                     context.db_name)
     archive_path = os.path.join(os.path.dirname(local_backup_path),
                                 '{}.tar.xz'.format(data_release_version))
     arcname = os.path.basename(local_backup_path)

--- a/src/azanium/util.py
+++ b/src/azanium/util.py
@@ -38,8 +38,8 @@ echo_retry = functools.partial(click.secho, fg='cyan')
 pkgpath = functools.partial(resource_filename, __package__)
 
 
-aws_state = functools.partial(shelve.open,
-                              os.path.join(os.getcwd(), '.db-migration.db'))
+def aws_state():
+    return shelve.open(os.path.expanduser('~/.db-migration.db'))
 
 
 def echo_warning(message,

--- a/src/azanium/util.py
+++ b/src/azanium/util.py
@@ -279,6 +279,10 @@ class CommandContext:
     def data_release_version(self):
         return self.versions['acedb_database']
 
+    @property
+    def db_name(self):
+        return self.datomic_url().rsplit('/', 1)[1]
+
     def exec_step(self,
                   step_n,
                   headline,


### PR DESCRIPTION
Latest updates, reflecting change to using a non-ephemeral instance.
This is what was used to produce the migration of WS254.

It's not in "finished" state - A WormBase administrator now needs to provide a "migration user" with:
 - The instance id of the migration instance (so they can start and stop the instance to perform the migration via `aws ec2`)

Additionally, before migration users can use this to perform a migration,
they will need to provide a public ssh key to someone who has access to the instance (presently, this is just myself)