### PR TITLE
Fixes issue with last step of db-migration.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@
 =================
 
 - Download the annotated models file separately (Fixes #8).
-
+- Fix last step (backup and transfer to S3)
 
 0.19 (2016-10-11)
 =================

--- a/src/azanium/datomic.py
+++ b/src/azanium/datomic.py
@@ -10,7 +10,7 @@ logger = log.get_logger(namespace=__name__)
 
 
 def backup_db(context, local_backup_path):
-    from_uri = context.datomic_url(context.db_name)
+    from_uri = context.datomic_url()
     to_uri = 'file://' + local_backup_path
     cmd = ['bin/datomic',
            util.jvm_mem_opts(0.20),


### PR DESCRIPTION
Upload of the migrated database would fail, since the API for
`CommandContext.datomic_url` had changed, but the call site did not.

The result was the datomic_url was maltformed when attempting to perform
the backup to S3.